### PR TITLE
feat: Zero-downtime rolling update and Grafana dashboard fixes

### DIFF
--- a/k8s/7.api.yaml
+++ b/k8s/7.api.yaml
@@ -5,7 +5,12 @@ metadata:
   name: hyuabot-backend-kotlin
   namespace: hyuabot
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: hyuabot-backend-kotlin
@@ -14,6 +19,7 @@ spec:
       labels:
         app: hyuabot-backend-kotlin
     spec:
+      terminationGracePeriodSeconds: 80
       containers:
       - name: api
         image: localhost:5000/hyuabot-backend-kotlin:latest
@@ -29,6 +35,10 @@ spec:
           limits:
             memory: "4Gi"
             cpu: "2000m"
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sh", "-c", "sleep 15"]
         readinessProbe:
           httpGet:
             path: /actuator/health

--- a/k8s/9.monitoring.yaml
+++ b/k8s/9.monitoring.yaml
@@ -244,7 +244,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
           "fieldConfig": { "defaults": { "unit": "percent", "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] }, "color": { "mode": "thresholds" } }, "overrides": [] },
-          "targets": [ { "expr": "100 * sum(rate(http_server_requests_seconds_count{application=\"$application\", status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{application=\"$application\"}[5m])), 0.001)", "refId": "A" } ]
+          "targets": [ { "expr": "100 * (sum(rate(http_server_requests_seconds_count{application=\"$application\", status=~\"5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(http_server_requests_seconds_count{application=\"$application\"}[5m])), 0.001)", "refId": "A" } ]
         },
         {
           "title": "Node CPU %", "type": "stat",
@@ -311,7 +311,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "gridPos": { "h": 7, "w": 12, "x": 12, "y": 21 },
           "fieldConfig": { "defaults": { "unit": "percent" }, "overrides": [] },
-          "targets": [ { "expr": "100 * sum(rate(http_server_requests_seconds_count{application=\"$application\", status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{application=\"$application\"}[5m])), 0.001)", "legendFormat": "5xx %", "refId": "A" } ]
+          "targets": [ { "expr": "100 * (sum(rate(http_server_requests_seconds_count{application=\"$application\", status=~\"5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(http_server_requests_seconds_count{application=\"$application\"}[5m])), 0.001)", "legendFormat": "5xx %", "refId": "A" } ]
         },
         {
           "title": "Latency percentiles", "type": "timeseries",
@@ -332,11 +332,21 @@ data:
           "targets": [ { "expr": "topk(5, sum by (uri) (rate(http_server_requests_seconds_count{application=\"$application\"}[5m])))", "legendFormat": "{{uri}}", "refId": "A" } ]
         },
 
-        { "type": "row", "title": "JVM", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 35 } },
+        {
+          "title": "Non-2XX requests (URI × status)", "type": "table",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 35 },
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [ { "matcher": { "id": "byName", "options": "Value" }, "properties": [ { "id": "displayName", "value": "Requests (1h)" } ] } ] },
+          "options": { "sortBy": [ { "displayName": "Requests (1h)", "desc": true } ] },
+          "targets": [ { "expr": "sort_desc(sum by (uri, status) (increase(http_server_requests_seconds_count{application=\"$application\", status!~\"2..\"}[1h])))", "format": "table", "instant": true, "legendFormat": "", "refId": "A" } ],
+          "transformations": [ { "id": "organize", "options": { "excludeByName": { "Time": true, "application": true, "instance": true, "job": true }, "renameByName": { "uri": "URI", "status": "Status Code", "Value": "Requests (1h)" } } } ]
+        },
+
+        { "type": "row", "title": "JVM", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 44 } },
         {
           "title": "Memory", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 36 },
+          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 45 },
           "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
           "targets": [
             { "expr": "sum(jvm_memory_used_bytes{application=\"$application\", area=\"heap\"})", "legendFormat": "heap used", "refId": "A" },
@@ -347,7 +357,7 @@ data:
         {
           "title": "GC pause", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 36 },
+          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 45 },
           "targets": [
             { "expr": "sum(rate(jvm_gc_pause_seconds_sum{application=\"$application\"}[5m]))", "legendFormat": "pause time/s", "refId": "A" },
             { "expr": "sum(rate(jvm_gc_pause_seconds_count{application=\"$application\"}[5m]))", "legendFormat": "pauses/s", "refId": "B" }
@@ -356,7 +366,7 @@ data:
         {
           "title": "Threads", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 8, "x": 0, "y": 43 },
+          "gridPos": { "h": 7, "w": 8, "x": 0, "y": 52 },
           "targets": [
             { "expr": "jvm_threads_live_threads{application=\"$application\"}", "legendFormat": "live", "refId": "A" },
             { "expr": "jvm_threads_daemon_threads{application=\"$application\"}", "legendFormat": "daemon", "refId": "B" },
@@ -366,29 +376,29 @@ data:
         {
           "title": "Allocation rate", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 8, "x": 8, "y": 43 },
+          "gridPos": { "h": 7, "w": 8, "x": 8, "y": 52 },
           "fieldConfig": { "defaults": { "unit": "Bps" }, "overrides": [] },
           "targets": [ { "expr": "rate(jvm_gc_memory_allocated_bytes_total{application=\"$application\"}[5m])", "legendFormat": "allocated/s", "refId": "A" } ]
         },
         {
           "title": "Classes loaded", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 8, "x": 16, "y": 43 },
+          "gridPos": { "h": 7, "w": 8, "x": 16, "y": 52 },
           "targets": [ { "expr": "jvm_classes_loaded_classes{application=\"$application\"}", "legendFormat": "loaded", "refId": "A" } ]
         },
 
-        { "type": "row", "title": "System (Node)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 } },
+        { "type": "row", "title": "System (Node)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 59 } },
         {
           "title": "CPU by mode", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 51 },
+          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 60 },
           "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
           "targets": [ { "expr": "sum by (mode) (rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]))", "legendFormat": "{{mode}}", "refId": "A" } ]
         },
         {
           "title": "Memory", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 51 },
+          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 60 },
           "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
           "targets": [
             { "expr": "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes", "legendFormat": "used", "refId": "A" },
@@ -398,14 +408,14 @@ data:
         {
           "title": "Filesystem usage % (/)", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 8, "x": 0, "y": 58 },
+          "gridPos": { "h": 7, "w": 8, "x": 0, "y": 67 },
           "fieldConfig": { "defaults": { "unit": "percent" }, "overrides": [] },
           "targets": [ { "expr": "100 * (1 - node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"})", "legendFormat": "{{mountpoint}}", "refId": "A" } ]
         },
         {
           "title": "Disk I/O", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 8, "x": 8, "y": 58 },
+          "gridPos": { "h": 7, "w": 8, "x": 8, "y": 67 },
           "fieldConfig": { "defaults": { "unit": "Bps" }, "overrides": [] },
           "targets": [
             { "expr": "sum(rate(node_disk_read_bytes_total[5m]))", "legendFormat": "read", "refId": "A" },
@@ -415,7 +425,7 @@ data:
         {
           "title": "Network", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 8, "x": 16, "y": 58 },
+          "gridPos": { "h": 7, "w": 8, "x": 16, "y": 67 },
           "fieldConfig": { "defaults": { "unit": "Bps" }, "overrides": [] },
           "targets": [
             { "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lo|veth.*|cni.*|flannel.*\"}[5m]))", "legendFormat": "rx", "refId": "A" },
@@ -425,7 +435,7 @@ data:
         {
           "title": "Load average", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 65 },
+          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 74 },
           "targets": [
             { "expr": "node_load1", "legendFormat": "1m", "refId": "A" },
             { "expr": "node_load5", "legendFormat": "5m", "refId": "B" },
@@ -433,32 +443,32 @@ data:
           ]
         },
 
-        { "type": "row", "title": "Cache (Spring/Redis)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 71 } },
+        { "type": "row", "title": "Cache (Spring/Redis)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 80 } },
         {
           "title": "Hit ratio (overall)", "type": "gauge",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 6, "w": 6, "x": 0, "y": 72 },
+          "gridPos": { "h": 6, "w": 6, "x": 0, "y": 81 },
           "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 } ] }, "color": { "mode": "thresholds" } }, "overrides": [] },
           "targets": [ { "expr": "100 * sum(rate(cache_gets_total{application=\"$application\", result=\"hit\"}[5m])) / clamp_min(sum(rate(cache_gets_total{application=\"$application\"}[5m])), 0.001)", "refId": "A" } ]
         },
         {
           "title": "Hit ratio by cache", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 6, "w": 18, "x": 6, "y": 72 },
+          "gridPos": { "h": 6, "w": 18, "x": 6, "y": 81 },
           "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
           "targets": [ { "expr": "sum by (cache) (rate(cache_gets_total{application=\"$application\", result=\"hit\"}[5m])) / clamp_min(sum by (cache) (rate(cache_gets_total{application=\"$application\"}[5m])), 0.001)", "legendFormat": "{{cache}}", "refId": "A" } ]
         },
         {
           "title": "Gets by result (hit/miss)", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 78 },
+          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 87 },
           "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
           "targets": [ { "expr": "sum by (cache, result) (rate(cache_gets_total{application=\"$application\"}[5m]))", "legendFormat": "{{cache}} {{result}}", "refId": "A" } ]
         },
         {
           "title": "Puts & removals by cache", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 78 },
+          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 87 },
           "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
           "targets": [
             { "expr": "sum by (cache) (rate(cache_puts_total{application=\"$application\"}[5m]))", "legendFormat": "{{cache}} puts", "refId": "A" },
@@ -468,33 +478,33 @@ data:
         {
           "title": "Redis hit ratio (server)", "type": "gauge",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 6, "w": 6, "x": 0, "y": 85 },
+          "gridPos": { "h": 6, "w": 6, "x": 0, "y": 94 },
           "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 } ] }, "color": { "mode": "thresholds" } }, "overrides": [] },
           "targets": [ { "expr": "100 * rate(redis_keyspace_hits_total[5m]) / clamp_min(rate(redis_keyspace_hits_total[5m]) + rate(redis_keyspace_misses_total[5m]), 0.001)", "refId": "A" } ]
         },
         {
           "title": "Redis memory used %", "type": "gauge",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 6, "w": 6, "x": 6, "y": 85 },
+          "gridPos": { "h": 6, "w": 6, "x": 6, "y": 94 },
           "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 80 }, { "color": "red", "value": 95 } ] }, "color": { "mode": "thresholds" } }, "overrides": [] },
           "targets": [ { "expr": "100 * redis_memory_used_bytes / clamp_min(redis_memory_max_bytes, 1)", "refId": "A" } ]
         },
         {
           "title": "Cached keys", "type": "stat",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 6, "w": 6, "x": 12, "y": 85 },
+          "gridPos": { "h": 6, "w": 6, "x": 12, "y": 94 },
           "targets": [ { "expr": "sum(redis_db_keys)", "refId": "A" } ]
         },
         {
           "title": "Connected clients", "type": "stat",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 6, "w": 6, "x": 18, "y": 85 },
+          "gridPos": { "h": 6, "w": 6, "x": 18, "y": 94 },
           "targets": [ { "expr": "redis_connected_clients", "refId": "A" } ]
         },
         {
           "title": "Evicted / expired keys", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 91 },
+          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 100 },
           "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
           "targets": [
             { "expr": "rate(redis_evicted_keys_total[5m])", "legendFormat": "evicted", "refId": "A" },
@@ -504,7 +514,7 @@ data:
         {
           "title": "Keyspace hits vs misses", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 91 },
+          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 100 },
           "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
           "targets": [
             { "expr": "rate(redis_keyspace_hits_total[5m])", "legendFormat": "hits", "refId": "A" },
@@ -514,7 +524,7 @@ data:
         {
           "title": "Redis memory used", "type": "timeseries",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 98 },
+          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 107 },
           "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
           "targets": [
             { "expr": "redis_memory_used_bytes", "legendFormat": "used", "refId": "A" },


### PR DESCRIPTION
## Summary

- **Zero-downtime rolling update** for the backend deployment:
  - Set `replicas: 2` for active load balancing across pods
  - Add `RollingUpdate` strategy with `maxUnavailable: 0`, `maxSurge: 1`
  - Add `preStop` sleep 15s to allow kube-proxy to drain connections before shutdown
  - Set `terminationGracePeriodSeconds: 80s` to accommodate preStop + Spring Boot graceful shutdown (60s)
- **Grafana dashboard fixes**:
  - Fix HTTP 5XX stat showing "No data" → now returns 0% when no errors
  - Fix Error Rate % showing "No data" → same `or vector(0)` fix
  - Add "Non-2XX requests (URI × status)" table panel for easy error log inspection

## Notes

- Pairs with hyuabot-backend-kotlin#69 which enables `server.shutdown=graceful` on the Spring Boot side
- Server requires `kubectl apply -f k8s/7.api.yaml -n hyuabot` and `kubectl apply -f k8s/9.monitoring.yaml -n hyuabot` followed by `kubectl rollout restart deployment/grafana -n hyuabot`