### PR TITLE
feat: Add Live Activity APNs environment

### DIFF
--- a/k8s/2.secret.yaml
+++ b/k8s/2.secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: API-KEYS
+  name: secret
   namespace: hyuabot
 type: Opaque
 data:
@@ -10,3 +10,6 @@ data:
   DB_ID: <base64 encoded value>
   DB_PASSWORD: <base64 encoded value>
   GRAFANA_ADMIN_PASSWORD: <base64 encoded value>
+  APNS_TEAM_ID: <base64 encoded value>
+  APNS_KEY_ID: <base64 encoded value>
+  APNS_PRIVATE_KEY: <base64 encoded value>

--- a/k8s/7.api.yaml
+++ b/k8s/7.api.yaml
@@ -28,6 +28,25 @@ spec:
         env:
         - name: JAVA_TOOL_OPTIONS
           value: "-XX:MaxRAMPercentage=75.0"
+        - name: APNS_LIVE_ACTIVITY_ENABLED
+          value: "true"
+        - name: APNS_BUNDLE_ID
+          value: "net.jaram.hyuabot"
+        - name: APNS_TEAM_ID
+          valueFrom:
+            secretKeyRef:
+              name: secret
+              key: APNS_TEAM_ID
+        - name: APNS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: secret
+              key: APNS_KEY_ID
+        - name: APNS_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret
+              key: APNS_PRIVATE_KEY
         resources:
           requests:
             memory: "1Gi"

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,9 @@ kubectl apply -f k8s/8.kakao.yaml
 | `METRO_API_KEY`     | subway-realtime-updater                |
 | `WEATHER_API_KEY`   | weather-updater                        |
 | `GOOGLE_PROJECT_ID` | library-updater (Firebase FCM)         |
+| `APNS_TEAM_ID`      | backend Live Activity APNs push        |
+| `APNS_KEY_ID`       | backend Live Activity APNs push        |
+| `APNS_PRIVATE_KEY`  | backend Live Activity APNs push        |
 
 ### Persistent storage
 


### PR DESCRIPTION
## Summary

- Wire APNs Live Activity environment variables into the backend deployment.
- Add APNs provider credentials to the Kubernetes secret placeholder.
- Align the secret manifest name with the name referenced by existing workloads.
- Document the APNs secret keys required by the backend.

## Notes

- Pairs with hyuabot-backend-kotlin#84, which adds the backend Live Activity APNs sender and token registration API.
- Development and production APNs tokens are handled by the backend per token registration, so the deployment no longer needs a global sandbox switch.
- Before applying, populate `APNS_TEAM_ID`, `APNS_KEY_ID`, and `APNS_PRIVATE_KEY` with base64-encoded values in the cluster secret.

## Validation

- Parsed all Kubernetes manifests with Ruby YAML.
