### PR TITLE
fix: Refresh shuttle timetable materialized views

### DIFF
--- a/database/create_database.sql
+++ b/database/create_database.sql
@@ -318,21 +318,22 @@ create or replace function update_shuttle_timetable_view()
 returns trigger as $$
 begin
     refresh materialized view shuttle_timetable_view;
-    return new;
+    refresh materialized view shuttle_timetable_grouped_view;
+    return null;
 end;
 $$ language plpgsql;
 
 create trigger update_shuttle_timetable_view_timetable
 after insert or update or delete on shuttle_timetable
-for each row execute procedure update_shuttle_timetable_view();
+for each statement execute procedure update_shuttle_timetable_view();
 
 create trigger update_shuttle_timetable_view_route_stop
 after insert or update or delete on shuttle_route_stop
-for each row execute procedure update_shuttle_timetable_view();
+for each statement execute procedure update_shuttle_timetable_view();
 
 create trigger update_shuttle_timetable_view_route
 after insert or update or delete on shuttle_route
-for each row execute procedure update_shuttle_timetable_view();
+for each statement execute procedure update_shuttle_timetable_view();
 
 -- 통학버스 운행 노선
 create table if not exists commute_shuttle_route (


### PR DESCRIPTION
## Summary

- Refresh both shuttle timetable materialized views when source shuttle data changes.
- Change the shuttle timetable refresh triggers from row-level to statement-level execution.
- Return `null` from the statement-level trigger function because the trigger return value is ignored.

## Validation

- Parsed all Kubernetes manifests with Ruby YAML.
- Verified the schema contains both materialized view refresh statements and statement-level triggers.