### PR TITLE
feat: Add admin user invitation schema

### DIFF
--- a/database/create_database.sql
+++ b/database/create_database.sql
@@ -20,9 +20,11 @@ drop index if exists idx_bus_timetable;
 drop index if exists idx_subway_timetable;
 drop index if exists idx_menu;
 drop index if exists idx_admin_user_permission_permission;
+drop index if exists idx_admin_user_invitation_user_active;
 
 
 -- 관리자 계정 테이블 삭제
+drop table if exists admin_user_invitation cascade;
 drop table if exists admin_user_permission cascade;
 drop table if exists admin_user cascade;
 drop table if exists auth_refresh_token cascade;
@@ -91,12 +93,38 @@ drop table if exists campus cascade;
 -- 관리자 계정 테이블
 create table if not exists admin_user (
     user_id varchar(20) primary key,
-    password bytea not null,
+    password bytea,
     name varchar(20) not null,
     email varchar(50) not null,
     phone varchar(15) not null,
-    active boolean not null
+    active boolean not null,
+    auth_version integer not null default 0
 );
+
+create unique index if not exists idx_admin_user_email_normalized
+    on admin_user(lower(trim(email)));
+
+create table if not exists admin_user_invitation (
+    uuid uuid primary key,
+    user_id varchar(20) not null,
+    token_hash char(64) not null unique,
+    created_by varchar(20) not null,
+    expires_at timestamptz not null,
+    consumed_at timestamptz,
+    revoked_at timestamptz,
+    created_at timestamptz not null,
+    constraint fk_admin_user_invitation_user
+        foreign key (user_id)
+        references admin_user(user_id)
+        on delete cascade,
+    constraint fk_admin_user_invitation_creator
+        foreign key (created_by)
+        references admin_user(user_id)
+);
+
+create unique index if not exists idx_admin_user_invitation_user_active
+    on admin_user_invitation(user_id)
+    where consumed_at is null and revoked_at is null;
 
 create table if not exists admin_user_permission (
     user_id varchar(20) not null,

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ The `database/` directory contains the canonical PostgreSQL schema.
 
 | Domain          | Tables                                                                                    |
 |-----------------|-------------------------------------------------------------------------------------------|
-| Auth            | `admin_user`, `auth_refresh_token`                                                        |
+| Auth            | `admin_user`, `admin_user_invitation`, `auth_refresh_token`                               |
 | Bus             | `bus_route`, `bus_stop`, `bus_timetable`, `bus_realtime`, `bus_departure_log`             |
 | Subway          | `subway_route`, `subway_station`, `subway_timetable`, `subway_realtime`                   |
 | Shuttle         | `shuttle_route`, `shuttle_stop`, `shuttle_timetable`, `shuttle_period`, `shuttle_holiday` |


### PR DESCRIPTION
## Summary

- Allow pending administrator accounts to exist without a password.
- Add an authentication version used to invalidate existing tokens after password changes.
- Enforce normalized administrator email uniqueness.
- Add the one-time administrator invitation table, constraints, and lookup indexes.

## Notes

- Pairs with the backend and admin frontend invitation changes.
- This PR intentionally does not include an environment migration script.
- Existing environments must apply the equivalent migration before deploying the paired backend change.
- No Kubernetes secret or manifest change is required.

## Validation

- `git diff --check`
- Reviewed the PostgreSQL 15 DDL, constraints, foreign keys, partial unique index, and lookup indexes.